### PR TITLE
feat: make admin tools small 

### DIFF
--- a/example/src/components/ChatboxTest.tsx
+++ b/example/src/components/ChatboxTest.tsx
@@ -35,8 +35,8 @@ const ChatboxTest: FC<Props> = () => {
   const [lang, setLang] = useState(DEFAULT_LANG);
   const [chatId, setChatId] = useState(DEFAULT_CHAT_ID);
 
+  // adapt the width of the chatbox to simulate the width used on Graasp
   const onCheckPanelWidth = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log(e.target.value);
     if (Number(e.target.value) === 0) {
       setTestWidth(GRAASP_PANEL_WIDTH);
     } else {

--- a/example/src/components/ChatboxTest.tsx
+++ b/example/src/components/ChatboxTest.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import React, { FC, useState } from 'react';
 import {
   Checkbox,
   FormControl,
@@ -12,7 +12,11 @@ import {
   Typography,
 } from '@material-ui/core';
 import ChatboxWrapper from './ChatboxWrapper';
-import { DEFAULT_CHAT_ID, DEFAULT_LANG } from '../config/constants';
+import {
+  DEFAULT_CHAT_ID,
+  DEFAULT_LANG,
+  GRAASP_PANEL_WIDTH,
+} from '../config/constants';
 
 const useStyles = makeStyles((theme) => ({
   testContainer: {
@@ -26,12 +30,23 @@ type Props = {};
 const ChatboxTest: FC<Props> = () => {
   const classes = useStyles();
   const [showTools, setShowTools] = useState(false);
+  const [testWidth, setTestWidth] = useState(GRAASP_PANEL_WIDTH);
   const [showHeader, setShowHeader] = useState(false);
   const [lang, setLang] = useState(DEFAULT_LANG);
   const [chatId, setChatId] = useState(DEFAULT_CHAT_ID);
+
+  const onCheckPanelWidth = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(e.target.value);
+    if (Number(e.target.value) === 0) {
+      setTestWidth(GRAASP_PANEL_WIDTH);
+    } else {
+      setTestWidth(0);
+    }
+  };
+
   return (
     <Grid container direction="row">
-      <Grid item xs>
+      <Grid item style={{ width: testWidth || 'auto' }}>
         <ChatboxWrapper
           chatId={chatId}
           lang={lang}
@@ -100,6 +115,16 @@ const ChatboxTest: FC<Props> = () => {
                 />
               }
               label={'Show Admin tools'}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={Boolean(testWidth)}
+                  value={testWidth}
+                  onChange={onCheckPanelWidth}
+                />
+              }
+              label={'Use Graasp Panel Width'}
             />
           </FormControl>
         </Grid>

--- a/example/src/config/constants.js
+++ b/example/src/config/constants.js
@@ -14,5 +14,7 @@ export const API_HOST =
 export const HEADER_SIZE = 64;
 export const TOOLS_SIZE = 64;
 
+export const GRAASP_PANEL_WIDTH = 280;
+
 export const DEFAULT_CHAT_ID = '39370f67-2153-4ab9-9679-b1966542d27d';
 export const DEFAULT_LANG = 'fr';

--- a/src/components/AdminTools.tsx
+++ b/src/components/AdminTools.tsx
@@ -13,7 +13,7 @@ const AdminTools: FC<Props> = ({ variant = ToolVariants.BUTTON }) => {
   return (
     <Box flexDirection="row" data-cy={adminToolsContainerCypress}>
       <ExportChat variant={variant} />
-      <ClearChat />
+      <ClearChat variant={variant} />
     </Box>
   );
 };

--- a/src/components/Chatbox.tsx
+++ b/src/components/Chatbox.tsx
@@ -105,6 +105,7 @@ const Chatbox: FC<Props> = ({
               <Container id={id} maxWidth="md" className={classes.container}>
                 <Messages
                   currentMember={currentMember}
+                  isAdmin={showAdminTools}
                   height={height - inputBarHeight - SAFETY_MARGIN}
                   deleteMessageFunction={deleteMessageFunction}
                 />
@@ -114,7 +115,7 @@ const Chatbox: FC<Props> = ({
                     sendMessageFunction={sendMessageFunction}
                     editMessageFunction={editMessageFunction}
                   />
-                  {showAdminTools && <AdminTools variant="button" />}
+                  {showAdminTools && <AdminTools variant="icon" />}
                 </div>
               </Container>
             </>

--- a/src/components/ClearChat.tsx
+++ b/src/components/ClearChat.tsx
@@ -1,31 +1,65 @@
-import { FC, useState } from 'react';
+import { FC, ReactElement, useState } from 'react';
 import ConfirmationDialog from './common/ConfirmationDialog';
 import { useTranslation } from 'react-i18next';
 import { useHooksContext } from '../context/HooksContext';
 import { useMessagesContext } from '../context/MessagesContext';
 import { Button } from '@graasp/ui';
 import { clearChatButtonCypress } from '../config/selectors';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Tooltip, Typography } from '@material-ui/core';
 import ExportChat from './ExportChat';
+import { ToolVariants, ToolVariantsType } from '../types';
+import IconButton from '@material-ui/core/IconButton';
+import { DeleteForever } from '@material-ui/icons';
 
-const ClearChat: FC = () => {
+type Prop = {
+  variant?: ToolVariantsType;
+};
+
+const ClearChat: FC<Prop> = ({ variant = ToolVariants.BUTTON }) => {
   const [openConfirmation, setOpenConfirmation] = useState(false);
   const { t } = useTranslation();
   const { clearChatHook: clearChat } = useHooksContext();
-  const { chatId } = useMessagesContext();
+  const { chatId, messages } = useMessagesContext();
+
+  if (!clearChat || !messages || !messages?.size) {
+    return null;
+  }
 
   const handleClearChat = (): void => {
     clearChat?.(chatId);
   };
 
+  const getContent = (contentType: ToolVariantsType): ReactElement => {
+    const text = t('Clear Chat');
+
+    switch (contentType) {
+      case ToolVariants.ICON:
+        return (
+          <Tooltip title={text}>
+            <IconButton
+              data-cy={clearChatButtonCypress}
+              onClick={(): void => setOpenConfirmation(true)}
+            >
+              <DeleteForever color="primary" />
+            </IconButton>
+          </Tooltip>
+        );
+      case ToolVariants.BUTTON:
+        return (
+          <Button
+            variant="outlined"
+            dataCy={clearChatButtonCypress}
+            onClick={(): void => setOpenConfirmation(true)}
+          >
+            {text}
+          </Button>
+        );
+    }
+  };
+
   return (
     <>
-      <Button
-        dataCy={clearChatButtonCypress}
-        onClick={(): void => setOpenConfirmation(true)}
-      >
-        {t('Clear Chat')}
-      </Button>
+      {getContent(variant)}
       <ConfirmationDialog
         open={openConfirmation}
         title={t('Clear Chat Confirmation')}
@@ -39,6 +73,7 @@ const ClearChat: FC = () => {
             <ExportChat variant="button" text={t('Save Chat')} />
           </Box>
         }
+        confirmText={t('Clear Chat')}
         onConfirm={(): void => {
           setOpenConfirmation(false);
           handleClearChat();

--- a/src/components/ExportChat.tsx
+++ b/src/components/ExportChat.tsx
@@ -7,7 +7,7 @@ import {
   EXPORT_DATE_FORMAT,
 } from '../constants';
 import { ExportedChatMessage, ToolVariants, ToolVariantsType } from '../types';
-import { IconButton } from '@material-ui/core';
+import { IconButton, Tooltip } from '@material-ui/core';
 import { GetApp } from '@material-ui/icons';
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
@@ -58,15 +58,18 @@ const ExportChat: FC<Props> = ({ variant = ToolVariants.ICON, text }) => {
   };
 
   const getContent = (variant: ToolVariantsType): ReactElement | null => {
+    const contentText: string = text || t('Download Chat');
     switch (variant) {
       case ToolVariants.ICON:
         return (
-          <IconButton>
-            <GetApp color="secondary" />
-          </IconButton>
+          <Tooltip title={contentText}>
+            <IconButton>
+              <GetApp color="primary" />
+            </IconButton>
+          </Tooltip>
         );
       case ToolVariants.BUTTON:
-        return <Button>{text || t('Download Chat')}</Button>;
+        return <Button variant="outlined">{contentText}</Button>;
       default:
         return null;
     }

--- a/src/components/MessageActions.tsx
+++ b/src/components/MessageActions.tsx
@@ -21,6 +21,7 @@ import { useEditingContext } from '../context/EditingContext';
 
 type Props = {
   message: ChatMessage;
+  isOwn?: boolean;
   deleteMessageFunction?: (message: PartialChatMessage) => void;
 };
 
@@ -33,7 +34,11 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const MessageActions: FC<Props> = ({ message, deleteMessageFunction }) => {
+const MessageActions: FC<Props> = ({
+  message,
+  deleteMessageFunction,
+  isOwn = false,
+}) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const classes = useStyles();
@@ -80,16 +85,21 @@ const MessageActions: FC<Props> = ({ message, deleteMessageFunction }) => {
           horizontal: 'right',
         }}
       >
-        <MenuItem
-          data-cy={editMenuItemCypress}
-          onClick={handleEditMessage}
-          dense
-        >
-          <ListItemIcon className={classes.menu}>
-            <Edit color="primary" />
-          </ListItemIcon>
-          <ListItemText>{t(CHATBOX.EDIT_BUTTON)}</ListItemText>
-        </MenuItem>
+        {
+          // only show the edit button on own messages
+          isOwn && (
+            <MenuItem
+              data-cy={editMenuItemCypress}
+              onClick={handleEditMessage}
+              dense
+            >
+              <ListItemIcon className={classes.menu}>
+                <Edit color="primary" />
+              </ListItemIcon>
+              <ListItemText>{t(CHATBOX.EDIT_BUTTON)}</ListItemText>
+            </MenuItem>
+          )
+        }
         <MenuItem
           data-cy={deleteMenuItemCypress}
           onClick={handleDeleteMessage}

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -18,12 +18,14 @@ import { useMessagesContext } from '../context/MessagesContext';
 
 type Props = {
   currentMember: ImmutableMember;
+  isAdmin?: boolean;
   height: number;
   deleteMessageFunction?: (message: PartialChatMessage) => void;
 };
 
 const Messages: FC<Props> = ({
   currentMember,
+  isAdmin = false,
   height,
   deleteMessageFunction,
 }) => {
@@ -106,7 +108,7 @@ const Messages: FC<Props> = ({
                     message={message}
                     member={members?.find(({ id }) => id === message.creator)}
                   />
-                  {isOwnMessage && (
+                  {(isOwnMessage || isAdmin) && (
                     <MessageActions
                       message={message}
                       deleteMessageFunction={deleteMessageFunction}

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -111,6 +111,7 @@ const Messages: FC<Props> = ({
                   {(isOwnMessage || isAdmin) && (
                     <MessageActions
                       message={message}
+                      isOwn={isOwnMessage}
                       deleteMessageFunction={deleteMessageFunction}
                     />
                   )}

--- a/src/components/common/ConfirmationDialog.tsx
+++ b/src/components/common/ConfirmationDialog.tsx
@@ -16,6 +16,8 @@ type Props = {
   open: boolean;
   title: string;
   content: ReactElement<unknown> | string;
+  confirmText?: string;
+  cancelText?: string;
   onConfirm: () => void;
   onCancel: () => void;
 };
@@ -24,6 +26,8 @@ const ConfirmationDialog: FC<Props> = ({
   open,
   title,
   content,
+  confirmText,
+  cancelText,
   onConfirm,
   onCancel,
 }) => {
@@ -35,14 +39,18 @@ const ConfirmationDialog: FC<Props> = ({
       <DialogContent>{content}</DialogContent>
       <DialogActions>
         <Button
-          variant="outlined"
+          variant="contained"
           onClick={onCancel}
           dataCy={cancelDialogButtonCypress}
         >
-          {t('Cancel')}
+          {cancelText || t('Cancel')}
         </Button>
-        <Button onClick={onConfirm} dataCy={confirmDialogButtonCypress}>
-          {t('Confirm')}
+        <Button
+          variant="outlined"
+          onClick={onConfirm}
+          dataCy={confirmDialogButtonCypress}
+        >
+          {confirmText || t('Confirm')}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
This PR makes admin tools small icons bellow the input field closes #35 
This also changes the appearance of the buttons in the confirmation dialog closes #37 (but not red)
And lastly it shows the menu list on other peoples messages so that admins can "delete messages". 

@pyphilia do we want to let them also edit the messages ? or only delete ? 

Also closes #36 