### PR TITLE
Fix overflow text

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,7 +5,7 @@
   "component": {
     "testFiles": "**/*.test.{js,ts,jsx,tsx}",
     "componentFolder": "src",
-    "viewportWidth": 500,
-    "viewportHeight": 700
+    "viewportWidth": 290,
+    "viewportHeight": 800
   }
 }

--- a/cypress/fixtures/chat_messages.ts
+++ b/cypress/fixtures/chat_messages.ts
@@ -9,7 +9,7 @@ export const CHAT_MESSAGES = [
     chatId: CHAT_ID,
     creator: CURRENT_MEMBER.id,
     createdAt: new Date().toISOString(),
-    updatedAt: '',
+    updatedAt: new Date().toISOString(),
     body: 'Some text\nOn multiple lines',
   },
   {
@@ -17,7 +17,7 @@ export const CHAT_MESSAGES = [
     chatId: CHAT_ID,
     creator: MEMBERS.BOB.id,
     createdAt: new Date().toISOString(),
-    updatedAt: '',
+    updatedAt: new Date().toISOString(),
     body: 'And here a text with 2\n\nLine breaks',
   },
   {
@@ -25,10 +25,49 @@ export const CHAT_MESSAGES = [
     chatId: CHAT_ID,
     creator: CURRENT_MEMBER.id,
     createdAt: new Date().toISOString(),
-    updatedAt: '',
+    updatedAt: new Date().toISOString(),
     body: 'Message',
   },
 ];
+export const MARKDOWN_COMMENT = {
+  id: v4(),
+  chatId: CHAT_ID,
+  creator: CURRENT_MEMBER.id,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  body: `# Test Title
+
+## Subtitle
+
+**Bold**, *Italic*, ~strike-through~, __undelined__
+
+Hello, i want you to by me:
+- Milk
+- Bread
+- Ice-cream
+  - Chocolat
+    - Dark
+    - Milk
+  - Vanilla
+
+> A quote
+
+And also don't forget to checkout [our awesome platform](https://graasp.org)
+
+\`some code\`
+
+## Table
+
+| a | b  |  c |  d  |
+| - | :- | -: | :-: |
+| hello | You | are | here ? |
+| hello | You | are | here ? |
+
+## Tasklist
+
+* [ ] to do
+* [x] done`,
+};
 
 export const spyMethod = (name: string): Cypress.Agent<sinon.SinonSpy> =>
   cy.spy(() => null).as(name);

--- a/cypress/fixtures/chat_messages.ts
+++ b/cypress/fixtures/chat_messages.ts
@@ -10,7 +10,15 @@ export const CHAT_MESSAGES = [
     creator: CURRENT_MEMBER.id,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    body: 'Some text\nOn multiple lines',
+    body: 'Some really long text that is going to be wrapped to the next line i think, we need to test.\nOn multiple lines',
+  },
+  {
+    id: v4(),
+    chatId: CHAT_ID,
+    creator: MEMBERS.BOB.id,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    body: 'A lengthy response to the previous message that i think a lot of people will like to read, since it really goes in deep into the topic.\nAnd here also a preview of the next topic.\n\nSigned Bob',
   },
   {
     id: v4(),

--- a/example/src/components/ChatboxTest.tsx
+++ b/example/src/components/ChatboxTest.tsx
@@ -1,13 +1,13 @@
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import {
   Checkbox,
   FormControl,
   FormControlLabel,
   FormLabel,
-  Grid,
   makeStyles,
   Radio,
   RadioGroup,
+  Slider,
   TextField,
   Typography,
 } from '@material-ui/core';
@@ -18,118 +18,127 @@ import {
   GRAASP_PANEL_WIDTH,
 } from '../config/constants';
 
-const useStyles = makeStyles((theme) => ({
-  testContainer: {
-    padding: theme.spacing(2),
-    background: 'lightblue',
-  },
-}));
-
 type Props = {};
 
 const ChatboxTest: FC<Props> = () => {
-  const classes = useStyles();
-  const [showTools, setShowTools] = useState(false);
   const [testWidth, setTestWidth] = useState(GRAASP_PANEL_WIDTH);
-  const [showHeader, setShowHeader] = useState(false);
+  const [showTools, setShowTools] = useState(false);
   const [lang, setLang] = useState(DEFAULT_LANG);
   const [chatId, setChatId] = useState(DEFAULT_CHAT_ID);
 
+  const useStyles = makeStyles((theme) => ({
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+    },
+    chatboxContainer: {
+      margin: theme.spacing(1),
+      width: testWidth,
+      padding: theme.spacing(0, 1),
+      border: 'solid darkblue 1px',
+      borderRadius: '6px',
+    },
+    testContainer: {
+      margin: theme.spacing(1),
+      display: 'flex',
+      flexDirection: 'column',
+      borderRadius: '6px',
+      padding: theme.spacing(2),
+      width: '400px',
+      border: 'solid darkred 1px',
+      '& > *': {
+        margin: theme.spacing(2, 0) + '!important',
+      },
+    },
+    textInputControl: {
+      width: '100%',
+    },
+    chatInputBox: {
+      backgroundColor: 'white',
+      // borderRadius: '8px',
+      // border: 'solid red 2px',
+    },
+  }));
+
+  const classes = useStyles();
+
   // adapt the width of the chatbox to simulate the width used on Graasp
-  const onCheckPanelWidth = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (Number(e.target.value) === 0) {
-      setTestWidth(GRAASP_PANEL_WIDTH);
+  const onChangePanelWidth = (_: unknown, newValue: number | number[]) => {
+    if (typeof newValue == 'number') {
+      setTestWidth(newValue);
     } else {
       setTestWidth(0);
     }
   };
 
   return (
-    <Grid container direction="row">
-      <Grid item style={{ width: testWidth || 'auto' }}>
+    <div className={classes.container}>
+      <div className={classes.testContainer}>
+        <Typography variant="h5">Test parameters</Typography>
+        <FormControlLabel
+          className={classes.textInputControl}
+          control={
+            <TextField
+              className={classes.chatInputBox}
+              variant="outlined"
+              value={chatId}
+              fullWidth
+              onChange={({ target }) => setChatId(target.value)}
+            />
+          }
+          label={'Chat Id'}
+          labelPlacement="top"
+        />
+        <FormControl>
+          <FormLabel component="legend">Language</FormLabel>
+          <RadioGroup
+            aria-label="language"
+            value={lang}
+            onChange={({ target }) => setLang(target.value)}
+          >
+            <FormControlLabel value="fr" control={<Radio />} label={'French'} />
+            <FormControlLabel
+              value="en"
+              control={<Radio />}
+              label={'English'}
+            />
+          </RadioGroup>
+        </FormControl>
+        <FormControl>
+          <FormLabel component="legend">Chatbox params</FormLabel>
+          <FormControlLabel
+            control={
+              <Checkbox
+                value={showTools}
+                onChange={() => setShowTools(!showTools)}
+              />
+            }
+            label={'Show Admin tools'}
+          />
+          <FormControlLabel
+            control={
+              <Slider
+                value={testWidth}
+                min={GRAASP_PANEL_WIDTH}
+                step={20}
+                max={800}
+                color={'secondary'}
+                onChange={onChangePanelWidth}
+              />
+            }
+            labelPlacement="top"
+            label={'Panel Width'}
+          />
+        </FormControl>
+      </div>
+      <div className={classes.chatboxContainer}>
         <ChatboxWrapper
           chatId={chatId}
           lang={lang}
-          showHeader={showHeader}
           showAdminTools={showTools}
         />
-      </Grid>
-      <Grid
-        className={classes.testContainer}
-        container
-        item
-        justifyContent="flex-end"
-        direction="column"
-        xs
-        spacing={2}
-      >
-        <Typography variant="h5">Test parameters</Typography>
-        <Grid item>
-          <FormControlLabel
-            control={
-              <TextField
-                variant="outlined"
-                value={chatId}
-                fullWidth
-                onChange={({ target }) => setChatId(target.value)}
-              />
-            }
-            label={'Chat Id'}
-            labelPlacement="top"
-          />
-        </Grid>
-        <Grid item>
-          <FormControl>
-            <FormLabel component="legend">Chatbox params</FormLabel>
-            <RadioGroup
-              aria-label="language"
-              value={lang}
-              onChange={({ target }) => setLang(target.value)}
-            >
-              <FormControlLabel
-                value="fr"
-                control={<Radio />}
-                label={'French'}
-              />
-              <FormControlLabel
-                value="en"
-                control={<Radio />}
-                label={'English'}
-              />
-            </RadioGroup>
-            <FormLabel component="legend">Chatbox params</FormLabel>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  value={showHeader}
-                  onChange={() => setShowHeader(!showHeader)}
-                />
-              }
-              label={'Show Header'}
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  value={showTools}
-                  onChange={() => setShowTools(!showTools)}
-                />
-              }
-              label={'Show Admin tools'}
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={Boolean(testWidth)}
-                  value={testWidth}
-                  onChange={onCheckPanelWidth}
-                />
-              }
-              label={'Use Graasp Panel Width'}
-            />
-          </FormControl>
-        </Grid>
-      </Grid>
-    </Grid>
+      </div>
+    </div>
   );
 };
 

--- a/example/src/components/ChatboxTest.tsx
+++ b/example/src/components/ChatboxTest.tsx
@@ -55,8 +55,6 @@ const ChatboxTest: FC<Props> = () => {
     },
     chatInputBox: {
       backgroundColor: 'white',
-      // borderRadius: '8px',
-      // border: 'solid red 2px',
     },
   }));
 

--- a/example/src/components/ChatboxWrapper.tsx
+++ b/example/src/components/ChatboxWrapper.tsx
@@ -23,7 +23,7 @@ type Props = {
 const ChatboxWrapper: FC<Props> = ({
   chatId,
   lang = DEFAULT_LANG,
-  showHeader = true,
+  showHeader = false,
   showAdminTools = false,
 }) => {
   // use kooks

--- a/example/src/components/ChatboxWrapper.tsx
+++ b/example/src/components/ChatboxWrapper.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 import { List } from 'immutable';
 import Chatbox, {
   ChatMessage,
@@ -10,7 +10,7 @@ import Chatbox, {
 import { MUTATION_KEYS } from '@graasp/query-client';
 import { useMutation, hooks } from '../config/queryClient';
 import { PartialNewChatMessage } from '../../../src';
-import { DEFAULT_LANG, HEADER_SIZE } from '../config/constants';
+import { DEFAULT_LANG } from '../config/constants';
 import { ClearChatHookType } from '../../../src/types';
 
 type Props = {
@@ -35,24 +35,6 @@ const ChatboxWrapper: FC<Props> = ({
   // get id of member that posted messages in the chat
   const memberIds = Array.from(
     new Set(chatMessages?.map(({ creator }: { creator: string }) => creator)),
-  );
-
-  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
-
-  useEffect(
-    () => {
-      const handleResize = () => {
-        setWindowHeight(window.innerHeight);
-      };
-      window.addEventListener('resize', handleResize);
-
-      // cleanup eventListener
-      return () => {
-        window.removeEventListener('resize', handleResize);
-      };
-    },
-    // only run on first render
-    [],
   );
 
   const member = new ImmutableMember(currentMember);
@@ -81,7 +63,6 @@ const ChatboxWrapper: FC<Props> = ({
     <Chatbox
       lang={lang}
       chatId={chatId}
-      height={windowHeight - (showHeader ? HEADER_SIZE : 0)}
       showHeader={showHeader}
       showAdminTools={showAdminTools}
       currentMember={member}

--- a/example/src/config/constants.js
+++ b/example/src/config/constants.js
@@ -14,7 +14,7 @@ export const API_HOST =
 export const HEADER_SIZE = 64;
 export const TOOLS_SIZE = 64;
 
-export const GRAASP_PANEL_WIDTH = 280;
+export const GRAASP_PANEL_WIDTH = 290;
 
 export const DEFAULT_CHAT_ID = '39370f67-2153-4ab9-9679-b1966542d27d';
 export const DEFAULT_LANG = 'fr';

--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
     "lodash.truncate": "4.4.2",
     "moment": "2.29.1",
     "react-csv": "2.2.2",
-    "react-i18next": "11.15.3"
+    "react-i18next": "11.15.3",
+    "react-markdown": "8.0.3",
+    "remark-breaks": "3.0.2",
+    "remark-gfm": "3.0.1"
   },
   "browserslist": [
     "last 1 Chrome version"

--- a/src/components/Chatbox.tsx
+++ b/src/components/Chatbox.tsx
@@ -55,12 +55,11 @@ const Chatbox: FC<Props> = ({
   currentMember,
   members,
 }) => {
-  const useStyles = makeStyles((theme) => ({
+  const useStyles = makeStyles(() => ({
     chatboxContainer: {
       // set height of full container
       height: 'calc(100vh - 16px)',
       minHeight: '0px',
-      padding: theme.spacing(0, 1),
       display: 'flex',
       flexDirection: 'column',
     },

--- a/src/components/Chatbox.tsx
+++ b/src/components/Chatbox.tsx
@@ -1,10 +1,9 @@
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useMemo } from 'react';
 import Container from '@material-ui/core/Container';
 import { makeStyles } from '@material-ui/core/styles';
 import { List } from 'immutable';
 import Messages from './Messages';
 import Header from './Header';
-import { DEFAULT_CHATBOX_HEIGHT, SAFETY_MARGIN } from '../constants';
 import type {
   ChatMessage,
   ClearChatHookType,
@@ -25,7 +24,6 @@ import AdminTools from './AdminTools';
 type Props = {
   id?: string;
   sendMessageBoxId?: string;
-  height?: number;
   messages?: List<ChatMessage>;
   isLoading?: boolean;
   sendMessageFunction?: (message: PartialNewChatMessage) => void;
@@ -44,7 +42,6 @@ type Props = {
 const Chatbox: FC<Props> = ({
   id,
   sendMessageBoxId,
-  height = DEFAULT_CHATBOX_HEIGHT,
   sendMessageFunction,
   deleteMessageFunction,
   editMessageFunction,
@@ -64,11 +61,11 @@ const Chatbox: FC<Props> = ({
       display: 'flex',
       flexDirection: 'column',
       padding: theme.spacing(0, 1),
-      height: height || DEFAULT_CHATBOX_HEIGHT,
+      height: 'calc(100vh - 16px)',
+      minHeight: '0px',
     },
     bottomContainer: {
       boxSizing: 'border-box',
-      paddingBottom: theme.spacing(1),
     },
   }));
   const classes = useStyles();
@@ -77,12 +74,6 @@ const Chatbox: FC<Props> = ({
     i18nInstance.changeLanguage(lang);
     return i18nInstance;
   }, [lang]);
-  const ref = useRef<HTMLDivElement>(null);
-  const [inputBarHeight, setInputBarHeight] = useState(0);
-
-  useEffect(() => {
-    setInputBarHeight(ref.current?.clientHeight || 0);
-  }, [showAdminTools, ref]);
 
   if (isLoading) {
     return null;
@@ -106,17 +97,14 @@ const Chatbox: FC<Props> = ({
                 <Messages
                   currentMember={currentMember}
                   isAdmin={showAdminTools}
-                  height={height - inputBarHeight - SAFETY_MARGIN}
                   deleteMessageFunction={deleteMessageFunction}
                 />
-                <div ref={ref} className={classes.bottomContainer}>
-                  <InputBar
-                    sendMessageBoxId={sendMessageBoxId}
-                    sendMessageFunction={sendMessageFunction}
-                    editMessageFunction={editMessageFunction}
-                  />
-                  {showAdminTools && <AdminTools variant="icon" />}
-                </div>
+                <InputBar
+                  sendMessageBoxId={sendMessageBoxId}
+                  sendMessageFunction={sendMessageFunction}
+                  editMessageFunction={editMessageFunction}
+                />
+                {showAdminTools && <AdminTools variant="icon" />}
               </Container>
             </>
           </MessagesContextProvider>

--- a/src/components/Chatbox.tsx
+++ b/src/components/Chatbox.tsx
@@ -1,5 +1,4 @@
 import { FC, useMemo } from 'react';
-import Container from '@material-ui/core/Container';
 import { makeStyles } from '@material-ui/core/styles';
 import { List } from 'immutable';
 import Messages from './Messages';
@@ -57,15 +56,20 @@ const Chatbox: FC<Props> = ({
   members,
 }) => {
   const useStyles = makeStyles((theme) => ({
-    container: {
+    chatboxContainer: {
+      // set height of full container
+      height: 'calc(100vh - 16px)',
+      minHeight: '0px',
+      padding: theme.spacing(0, 1),
       display: 'flex',
       flexDirection: 'column',
-      padding: theme.spacing(0, 1),
-      height: 'calc(100vh - 16px)',
+    },
+    container: {
       minHeight: '0px',
     },
     bottomContainer: {
-      boxSizing: 'border-box',
+      // no flex growing -> keep container at bottom of window
+      flex: 'none',
     },
   }));
   const classes = useStyles();
@@ -93,19 +97,21 @@ const Chatbox: FC<Props> = ({
           >
             <>
               {showHeader && <Header />}
-              <Container id={id} maxWidth="md" className={classes.container}>
+              <div className={classes.chatboxContainer} id={id}>
                 <Messages
                   currentMember={currentMember}
                   isAdmin={showAdminTools}
                   deleteMessageFunction={deleteMessageFunction}
                 />
-                <InputBar
-                  sendMessageBoxId={sendMessageBoxId}
-                  sendMessageFunction={sendMessageFunction}
-                  editMessageFunction={editMessageFunction}
-                />
-                {showAdminTools && <AdminTools variant="icon" />}
-              </Container>
+                <div className={classes.bottomContainer}>
+                  <InputBar
+                    sendMessageBoxId={sendMessageBoxId}
+                    sendMessageFunction={sendMessageFunction}
+                    editMessageFunction={editMessageFunction}
+                  />
+                  {showAdminTools && <AdminTools variant="icon" />}
+                </div>
+              </div>
             </>
           </MessagesContextProvider>
         </HooksContextProvider>

--- a/src/components/EditBanner.tsx
+++ b/src/components/EditBanner.tsx
@@ -25,6 +25,8 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     alignItems: 'left',
     width: '100%',
+    // magic to ensure that the container does not overflow its intended space
+    minWidth: '0px',
   },
   oldTextLabel: {
     color: theme.palette.primary.main,

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: '5px',
     margin: theme.spacing(1, 0),
     padding: theme.spacing(0.5, 1, 0),
-    maxWidth: '80%',
+    maxWidth: '60%',
     width: 'fit-content',
     minWidth: 100,
     // wrap text at box limit

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: '5px',
     margin: theme.spacing(1, 0),
     padding: theme.spacing(0.5, 1, 0),
-    maxWidth: '60%',
+    maxWidth: '70%',
     width: 'fit-content',
     minWidth: 100,
     // wrap text at box limit

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { Avatar } from '@graasp/ui';
 import { Variant } from '@graasp/ui/dist/types';
 import { useHooksContext } from '../context/HooksContext';
+import MessageBody from './MessageBody';
 
 const useStyles = makeStyles((theme) => ({
   message: {
@@ -24,6 +25,8 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '80%',
     width: 'fit-content',
     minWidth: 100,
+    // wrap text at box limit
+    wordBreak: 'break-word',
   },
   own: {
     background: grey[300],
@@ -90,9 +93,7 @@ const Message: FC<Props> = ({ message, currentMember, member }) => {
           <Typography variant="subtitle2">{`${creatorName}`}</Typography>
         </Box>
       )}
-      <Typography className={classes.messageText} variant="body1">
-        {message.body}
-      </Typography>
+      <MessageBody messageBody={message.body} />
       <Typography variant="caption" className={classes.time}>
         {`${
           // when the createdAt and updatedAt times are different it means the message has been modified

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -10,10 +10,12 @@ const useStyles = makeStyles(() => ({
     '& *': {
       marginBlockStart: '4px',
       marginBlockEnd: '4px',
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
     },
     '& p': {
       lineHeight: '1.5',
       fontSize: '1rem',
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
     },
     '& ul': {
       // define offset for list
@@ -47,7 +49,6 @@ const useStyles = makeStyles(() => ({
       color: 'blue',
       backgroundColor: 'blue',
     },
-    margin: '4px',
   },
 }));
 

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -28,6 +28,8 @@ const useStyles = makeStyles(() => ({
       wordWrap: 'break-word',
       whiteSpace: 'pre-wrap',
       fontSize: '90%',
+      fontFamily:
+        'ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace',
     },
     '& blockquote': {
       borderLeft: 'solid darkgray 4px',

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -4,26 +4,25 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   messageParagraphs: {
     // set margins for all elements
     '& *': {
-      marginBlockStart: '4px',
-      marginBlockEnd: '4px',
-      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+      marginBlockStart: theme.spacing(1),
+      marginBlockEnd: theme.spacing(1),
+      fontFamily: theme.typography.fontFamily,
     },
     '& p': {
       lineHeight: '1.5',
       fontSize: '1rem',
-      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
     },
     '& ul': {
       // define offset for list
-      paddingInlineStart: '20px',
+      paddingInlineStart: theme.spacing(2),
     },
     '& code': {
       padding: '0.2em 0.4em',
-      borderRadius: '6px',
+      borderRadius: theme.spacing(1),
       backgroundColor: 'silver',
       wordWrap: 'break-word',
       whiteSpace: 'pre-wrap',
@@ -35,7 +34,7 @@ const useStyles = makeStyles(() => ({
       borderLeft: 'solid darkgray 4px',
       color: 'darkgray',
       marginLeft: '0',
-      paddingLeft: '16px',
+      paddingLeft: theme.spacing(2),
     },
     '& table, th, td, tr': {
       border: 'solid black 1px ',

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -1,0 +1,71 @@
+import { FC } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  messageParagraphs: {
+    // set margins for all elements
+    '& *': {
+      marginBlockStart: '4px',
+      marginBlockEnd: '4px',
+    },
+    '& p': {
+      lineHeight: '1.5',
+      fontSize: '1rem',
+    },
+    '& ul': {
+      // define offset for list
+      paddingInlineStart: '20px',
+    },
+    '& code': {
+      padding: '0.2em 0.4em',
+      borderRadius: '6px',
+      backgroundColor: 'silver',
+      wordWrap: 'break-word',
+      whiteSpace: 'pre-wrap',
+      fontSize: '90%',
+    },
+    '& blockquote': {
+      borderLeft: 'solid darkgray 4px',
+      color: 'darkgray',
+      marginLeft: '0',
+      paddingLeft: '16px',
+    },
+    '& table, th, td, tr': {
+      border: 'solid black 1px ',
+    },
+    '& table': {
+      borderCollapse: 'collapse',
+    },
+    // alternate background colors in table rows
+    '& tr:nth-child(even)': {
+      backgroundColor: 'lightgray',
+    },
+    '& input[type="checkbox"]': {
+      color: 'blue',
+      backgroundColor: 'blue',
+    },
+    margin: '4px',
+  },
+}));
+
+type Props = {
+  messageBody: string;
+};
+
+const MessageBody: FC<Props> = ({ messageBody }) => {
+  const classes = useStyles();
+  return (
+    <ReactMarkdown
+      linkTarget="_blank"
+      className={classes.messageParagraphs}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+    >
+      {messageBody}
+    </ReactMarkdown>
+  );
+};
+
+export default MessageBody;

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -45,10 +45,6 @@ const useStyles = makeStyles(() => ({
     '& tr:nth-child(even)': {
       backgroundColor: 'lightgray',
     },
-    '& input[type="checkbox"]': {
-      color: 'blue',
-      backgroundColor: 'blue',
-    },
   },
 }));
 

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -32,8 +32,11 @@ const Messages: FC<Props> = ({
   const { messages, members } = useMessagesContext();
 
   const useStyles = makeStyles(() => ({
+    // used in accordance with the main container (input + scroll window)
     container: {
       overflowY: 'auto',
+      // grow container to push input at bottom of window
+      flex: 1,
       minHeight: '0px',
     },
     messagesContainer: {

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -9,7 +9,7 @@ import type {
   ImmutableMember,
   PartialChatMessage,
 } from '../types';
-import { BIG_NUMBER, DEFAULT_DATE_FORMAT } from '../constants';
+import { DEFAULT_DATE_FORMAT, SAFETY_MARGIN } from '../constants';
 import MessageActions from './MessageActions';
 import clsx from 'clsx';
 import { useEditingContext } from '../context/EditingContext';
@@ -19,14 +19,12 @@ import { useMessagesContext } from '../context/MessagesContext';
 type Props = {
   currentMember: ImmutableMember;
   isAdmin?: boolean;
-  height: number;
   deleteMessageFunction?: (message: PartialChatMessage) => void;
 };
 
 const Messages: FC<Props> = ({
   currentMember,
   isAdmin = false,
-  height,
   deleteMessageFunction,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -36,7 +34,7 @@ const Messages: FC<Props> = ({
   const useStyles = makeStyles(() => ({
     container: {
       overflowY: 'auto',
-      height: height,
+      minHeight: '0px',
     },
     messagesContainer: {
       display: 'flex',
@@ -67,8 +65,12 @@ const Messages: FC<Props> = ({
   // scroll down to last message at start, on new message and on editing message
   useEffect(() => {
     if (ref?.current) {
-      // really big number to scroll down
-      ref.current.scrollTop = BIG_NUMBER;
+      // temporarily hide the scroll bars when scrolling the container
+      ref.current.style.overflowY = 'hidden';
+      // scroll down the height of the container + some margin to make sure we are at the bottom
+      ref.current.scrollTop = ref.current.scrollHeight + SAFETY_MARGIN;
+      // re-activate scroll
+      ref.current.style.overflowY = 'auto';
     }
   }, [ref, messages, open]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export const INPUT_HEIGHT = 120;
 export const EDIT_BANNER_HEIGHT = 58;
 export const MAX_ROWS_INPUT = 4;
 export const BIG_NUMBER = 9999;
-export const SAFETY_MARGIN = 12;
+export const SAFETY_MARGIN = 64;
 export const DEFAULT_USER_NAME = 'Anonymous';
 export const MAX_USERNAME_LENGTH = 30;
 export const DEFAULT_DATE_FORMAT = 'DD MMM YYYY';
@@ -25,6 +25,9 @@ export const EXPORT_CSV_HEADERS = [
   { label: 'creator_name', key: 'creatorName' },
   { label: 'message_content', key: 'body' },
 ];
+
+export const SIDE_PANE_WIDTH = 290;
+export const SIDE_PANE_HEIGHT = 512;
 
 export const ICON_VARIANT = 'icon';
 export const BUTTON_VARIANT = 'button';

--- a/src/test/message-actions.test.tsx
+++ b/src/test/message-actions.test.tsx
@@ -18,6 +18,7 @@ import {
   inputTextFieldTextAreaCypress,
   messageActionsButtonCypress,
 } from '../config/selectors';
+import { SIDE_PANE_HEIGHT, SIDE_PANE_WIDTH } from '../constants';
 
 describe('Message actions', () => {
   beforeEach(() => {
@@ -67,6 +68,8 @@ describe('Delete action', () => {
 
 describe('Edit action', () => {
   beforeEach(() => {
+    // set the viewport to a narrower width
+    cy.viewport(SIDE_PANE_WIDTH, SIDE_PANE_HEIGHT);
     const editMessageSpy = spyMethod('editSpyMethod');
     const sendMessageSpy = spyMethod('sendSpyMethod');
     mount(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node", "cypress"]
   },
   "include": [
     "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,7 +2084,10 @@ __metadata:
     react-csv: 2.2.2
     react-dom: 17.0.2
     react-i18next: 11.15.3
+    react-markdown: 8.0.3
     react-scripts: 4.0.3
+    remark-breaks: 3.0.2
+    remark-gfm: 3.0.1
     rimraf: 3.0.2
     rollup: 2.63.0
     rollup-jest: 1.1.3
@@ -3500,6 +3503,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4.0.0":
+  version: 4.1.7
+  resolution: "@types/debug@npm:4.1.7"
+  dependencies:
+    "@types/ms": "*"
+  checksum: 0a7b89d8ed72526858f0b61c6fd81f477853e8c4415bb97f48b1b5545248d2ae389931680b94b393b993a7cfe893537a200647d93defe6d87159b96812305adc
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
@@ -3590,6 +3602,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: d076bb61f45d0fc42dee496ef8b1c2f8742e15d5e47e90e20d0243386e426c04d4efd408a48875ab432f7960b4ce3414db20ed0fbbfc7bcc89d84e574f6e045a
+  languageName: node
+  linkType: hard
+
+"@types/hast@npm:^2.0.0":
+  version: 2.3.4
+  resolution: "@types/hast@npm:2.3.4"
+  dependencies:
+    "@types/unist": "*"
+  checksum: fff47998f4c11e21a7454b58673f70478740ecdafd95aaf50b70a3daa7da9cdc57315545bf9c039613732c40b7b0e9e49d11d03fe9a4304721cdc3b29a88141e
   languageName: node
   linkType: hard
 
@@ -3707,6 +3728,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mdast@npm:^3.0.0":
+  version: 3.0.10
+  resolution: "@types/mdast@npm:3.0.10"
+  dependencies:
+    "@types/unist": "*"
+  checksum: 3f587bfc0a9a2403ecadc220e61031b01734fedaf82e27eb4d5ba039c0eb54db8c85681ccc070ab4df3f7ec711b736a82b990e69caa14c74bf7ac0ccf2ac7313
+  languageName: node
+  linkType: hard
+
+"@types/mdurl@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "@types/mdurl@npm:1.0.2"
+  checksum: 79c7e523b377f53cf1f5a240fe23d0c6cae856667692bd21bf1d064eafe5ccc40ae39a2aa0a9a51e8c94d1307228c8f6b121e847124591a9a828c3baf65e86e2
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:^1":
   version: 1.3.2
   resolution: "@types/mime@npm:1.3.2"
@@ -3725,6 +3762,13 @@ __metadata:
   version: 1.2.2
   resolution: "@types/minimist@npm:1.2.2"
   checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 0.7.31
+  resolution: "@types/ms@npm:0.7.31"
+  checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
   languageName: node
   linkType: hard
 
@@ -3785,7 +3829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
@@ -3984,6 +4028,13 @@ __metadata:
   dependencies:
     source-map: ^0.6.1
   checksum: 361e734404f23c9877edc51430e14e6f731124a4ba7590f0f584de35e3d084ac4f77bbcc5d17a69124d38f94f0d7a59992eb6a2dddaa6f6270df052ce2b6dc06
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*, @types/unist@npm:^2.0.0":
+  version: 2.0.6
+  resolution: "@types/unist@npm:2.0.6"
+  checksum: 25cb860ff10dde48b54622d58b23e66214211a61c84c0f15f88d38b61aa1b53d4d46e42b557924a93178c501c166aa37e28d7f6d994aba13d24685326272d5db
   languageName: node
   linkType: hard
 
@@ -6008,6 +6059,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bail@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "bail@npm:2.0.2"
+  checksum: aab4e8ccdc8d762bf3fdfce8e706601695620c0c2eda256dd85088dc0be3cfd7ff126f6e99c2bee1f24f5d418414aacf09d7f9702f16d6963df2fa488cda8824
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -6677,6 +6735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ccount@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "ccount@npm:2.0.1"
+  checksum: 48193dada54c9e260e0acf57fc16171a225305548f9ad20d5471e0f7a8c026aedd8747091dccb0d900cde7df4e4ddbd235df0d8de4a64c71b12f0d3303eeafd4
+  languageName: node
+  linkType: hard
+
 "chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -6719,6 +6784,13 @@ __metadata:
   version: 2.0.1
   resolution: "char-regex@npm:2.0.1"
   checksum: 8524c03fd7e58381dccf33babe885fe62731ae20755528b19c39945b8203479184f35247210dc9eeeef279cdbdd6511cd3182e0e1db8e4549bf2586470b7c204
+  languageName: node
+  linkType: hard
+
+"character-entities@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "character-entities@npm:2.0.1"
+  checksum: 1165064dbe1cc1f3cd5b28eba0e94f051d97bdd65463b0e763d6a8aae527443596f9e0e774a79c4a66de0c47ad95c94fc5fb2c7f6bec6551b5580f730a8da341
   languageName: node
   linkType: hard
 
@@ -7115,6 +7187,13 @@ __metadata:
   dependencies:
     delayed-stream: ~1.0.0
   checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+  languageName: node
+  linkType: hard
+
+"comma-separated-tokens@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "comma-separated-tokens@npm:2.0.2"
+  checksum: 8fa68ff2605233571536a802a7c712b0c766e0c5088e067be72740054e84d040865eea945c984924ae84932bcc3e25a99f71601220b438e875b5f42b87277767
   languageName: node
   linkType: hard
 
@@ -8427,7 +8506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -8490,6 +8569,15 @@ __metadata:
   version: 10.3.1
   resolution: "decimal.js@npm:10.3.1"
   checksum: 0351ac9f05fe050f23227aa6a4573bee2d58fa7378fcf28d969a8c789525032effb488a90320fd3fe86a66e17b4bc507d811b15eada5b7f0e7ec5d2af4c24a59
+  languageName: node
+  linkType: hard
+
+"decode-named-character-reference@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "decode-named-character-reference@npm:1.0.1"
+  dependencies:
+    character-entities: ^2.0.0
+  checksum: 4f67b088213497f7e19faffc1d2bf470bd3ceffd01b3be17857d4bce455e03728b33d3770761745916b0a230ecd917a1cba3c61156f0bd13958dc4fada19580a
   languageName: node
   linkType: hard
 
@@ -8642,6 +8730,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "dequal@npm:2.0.2"
+  checksum: 86c7a2c59f7b0797ed397c74b5fcdb744e48fc19440b70ad6ac59f57550a96b0faef3f1cfd5760ec5e6d3f7cb101f634f1f80db4e727b1dc8389bf62d977c0a0
+  languageName: node
+  linkType: hard
+
 "des.js@npm:^1.0.0":
   version: 1.0.1
   resolution: "des.js@npm:1.0.1"
@@ -8731,6 +8826,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "diff@npm:5.0.0"
+  checksum: f19fe29284b633afdb2725c2a8bb7d25761ea54d321d8e67987ac851c5294be4afeab532bd84531e02583a3fe7f4014aa314a3eda84f5590e7a9e6b371ef3b46
   languageName: node
   linkType: hard
 
@@ -9425,6 +9527,13 @@ __metadata:
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
   checksum: 98b48897d93060f2322108bf29db0feba7dd774be96cd069458d1453347b25ce8682ecc39859d4bca2203cc0ab19c237bcc71755eff49a0f8d90beadeeba5cc5
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
   languageName: node
   linkType: hard
 
@@ -10390,7 +10499,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.2, extend@npm:~3.0.2":
+"extend@npm:^3.0.0, extend@npm:^3.0.2, extend@npm:~3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
@@ -11612,6 +11721,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-whitespace@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "hast-util-whitespace@npm:2.0.0"
+  checksum: abeb5386075bfb0facfce89eed0e13d2cb27a0910cec8fd234b48821a1538387a73fa7f458842e8c404148dc69434acbc10488d75b02817e460652c2c894c024
+  languageName: node
+  linkType: hard
+
 "he@npm:^1.2.0":
   version: 1.2.0
   resolution: "he@npm:1.2.0"
@@ -12254,6 +12370,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inline-style-parser@npm:0.1.1":
+  version: 0.1.1
+  resolution: "inline-style-parser@npm:0.1.1"
+  checksum: 5d545056a3e1f2bf864c928a886a0e1656a3517127d36917b973de581bd54adc91b4bf1febcb0da054f204b4934763f1a4e09308b4d55002327cf1d48ac5d966
+  languageName: node
+  linkType: hard
+
 "internal-ip@npm:^4.3.0":
   version: 4.3.0
   resolution: "internal-ip@npm:4.3.0"
@@ -12400,6 +12523,13 @@ __metadata:
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "is-buffer@npm:2.0.5"
+  checksum: 764c9ad8b523a9f5a32af29bdf772b08eb48c04d2ad0a7240916ac2688c983bf5f8504bf25b35e66240edeb9d9085461f9b5dae1f3d2861c6b06a65fe983de42
   languageName: node
   linkType: hard
 
@@ -12702,6 +12832,13 @@ __metadata:
   version: 3.0.0
   resolution: "is-plain-obj@npm:3.0.0"
   checksum: a6ebdf8e12ab73f33530641972a72a4b8aed6df04f762070d823808303e4f76d87d5ea5bd76f96a7bbe83d93f04ac7764429c29413bd9049853a69cb630fb21c
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-plain-obj@npm:4.0.0"
+  checksum: a6bb55a90636345a64c6153b74d85a9b6440f9975f4dcc57eed596c280b7ba228c71c406355a3147ed0488330d2743d5756e052c9492b1aa4f7dcd281f08c4b6
   languageName: node
   linkType: hard
 
@@ -14399,6 +14536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kleur@npm:^4.0.3":
+  version: 4.1.4
+  resolution: "kleur@npm:4.1.4"
+  checksum: 7f6db36e378045dec14acd3cbf0b1e59130c09e984ee8b8ce56dd2d2257cfff90389c1e8f8b19bd09dd5d241080566a814b4ccd99fdcef91f59ef93ec33c8a44
+  languageName: node
+  linkType: hard
+
 "klona@npm:^2.0.4, klona@npm:^2.0.5":
   version: 2.0.5
   resolution: "klona@npm:2.0.5"
@@ -14755,6 +14899,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "longest-streak@npm:3.0.1"
+  checksum: 3b59c4c04ce3c70f137e339c10d574026fa3a711c45dc0e69a63a2c0ac981e57f837e1d5b64b991eee5234c4fa46fa10886a20626fb739ed3b04b77bcf6d14a8
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.1.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -14907,6 +15058,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-table@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "markdown-table@npm:3.0.2"
+  checksum: 7bd9eb54e7ac15165f79730ac6357b8194294552f727bcb34e29f3f1b72823c1220cb61153ebf0962c8faac4d25e49c62e8e9471cd6352a67cdca99928ecade1
+  languageName: node
+  linkType: hard
+
 "match-sorter@npm:^6.0.2":
   version: 6.3.1
   resolution: "match-sorter@npm:6.3.1"
@@ -14928,6 +15086,157 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-definitions@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "mdast-util-definitions@npm:5.1.0"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    "@types/unist": ^2.0.0
+    unist-util-visit: ^3.0.0
+  checksum: a5237dc5925d965ec5f4c237b8d2fbc4728c18402f4f0cea0c947fb6241d7f2c7264b8bd5000363800388003d1474d57f5d5d29e0605a504bd186e59ddf8906a
+  languageName: node
+  linkType: hard
+
+"mdast-util-find-and-replace@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "mdast-util-find-and-replace@npm:2.1.0"
+  dependencies:
+    escape-string-regexp: ^5.0.0
+    unist-util-is: ^5.0.0
+    unist-util-visit-parents: ^4.0.0
+  checksum: 2df955899edb71fdd9f09a639572b281ec6e9be1533469cdbd7f1f16232a576adbd423f914182684f9516897143a5a797c45182848c0f83807d2c30a582a3c03
+  languageName: node
+  linkType: hard
+
+"mdast-util-from-markdown@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "mdast-util-from-markdown@npm:1.2.0"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    "@types/unist": ^2.0.0
+    decode-named-character-reference: ^1.0.0
+    mdast-util-to-string: ^3.1.0
+    micromark: ^3.0.0
+    micromark-util-decode-numeric-character-reference: ^1.0.0
+    micromark-util-decode-string: ^1.0.0
+    micromark-util-normalize-identifier: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    unist-util-stringify-position: ^3.0.0
+    uvu: ^0.5.0
+  checksum: fadc3521a3d95f4adbadad462ca27c28b3bfe08740ae158dc0c4a22329bf5593254d98b8fd4024ecad8c47c77ec275454dfacfb907ff1b98ff8f5de25c716d40
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-autolink-literal@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "mdast-util-gfm-autolink-literal@npm:1.0.2"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    ccount: ^2.0.0
+    mdast-util-find-and-replace: ^2.0.0
+    micromark-util-character: ^1.0.0
+  checksum: 75e12f21ec24552ba33725f69a06cd703e5586d2296ca9d180927b2293c036e1bd39108adba83e8cbbefcc45ffd8821fb561b4c107684ed87bd9e5e286ba03bd
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-footnote@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mdast-util-gfm-footnote@npm:1.0.1"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-to-markdown: ^1.3.0
+    micromark-util-normalize-identifier: ^1.0.0
+  checksum: 4caf69058b438c9e34004acfb1d2b20d58306898d760b889f73d27ed5702cd940be9fcb2a08f6e58b8d9d8e2b1c886c549cd7d23b659da5fb2ed87a22f44c13c
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-strikethrough@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mdast-util-gfm-strikethrough@npm:1.0.1"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-to-markdown: ^1.3.0
+  checksum: ce81222ab4c130516278f8db57be23bd529e9f8c30bb16ab5b2bf294c0dfd57f2dc7a010deede65f349a8d37be73f90dbaecd962f76f70befa8f43bcd32fe5b9
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-table@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "mdast-util-gfm-table@npm:1.0.4"
+  dependencies:
+    markdown-table: ^3.0.0
+    mdast-util-from-markdown: ^1.0.0
+    mdast-util-to-markdown: ^1.3.0
+  checksum: 56d9f0376b3da3e4cc0f5047d62a4eefa765934a1084822bc7804e7cf93c458c4bff2a917fa4e89c917287431a7284b656bf23ef89553e943d7f853ffefae693
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-task-list-item@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mdast-util-gfm-task-list-item@npm:1.0.1"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-to-markdown: ^1.3.0
+  checksum: 9bb0f162532f8e11e571802ed19301572479fe9507652c8fb3f648279bbde3baa9f6377d9492dbba61eedd96755f8aff9c7c259287875544fb751907d79da69e
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-gfm@npm:2.0.1"
+  dependencies:
+    mdast-util-from-markdown: ^1.0.0
+    mdast-util-gfm-autolink-literal: ^1.0.0
+    mdast-util-gfm-footnote: ^1.0.0
+    mdast-util-gfm-strikethrough: ^1.0.0
+    mdast-util-gfm-table: ^1.0.0
+    mdast-util-gfm-task-list-item: ^1.0.0
+    mdast-util-to-markdown: ^1.0.0
+  checksum: 8b39e6694521094ae28d12cbeff074ef3ec3f7f7ec59fbddd4e8a45a275e092c6ba6ecee4c720938eb3ee072ebd41d743b08cc0ab9171612a5aeddc1e78ae882
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-hast@npm:^12.1.0":
+  version: 12.1.1
+  resolution: "mdast-util-to-hast@npm:12.1.1"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/mdast": ^3.0.0
+    "@types/mdurl": ^1.0.0
+    mdast-util-definitions: ^5.0.0
+    mdurl: ^1.0.0
+    micromark-util-sanitize-uri: ^1.0.0
+    unist-builder: ^3.0.0
+    unist-util-generated: ^2.0.0
+    unist-util-position: ^4.0.0
+    unist-util-visit: ^4.0.0
+  checksum: 4c5a73e0463493d5ab2c033d42f8daead24d0808969bf21c3a720786784a347cedc1d3ae26b37737dbe3ea0839bc130bf7e20f3bc02e2387e6e7b0a5f94bafe4
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-markdown@npm:^1.0.0, mdast-util-to-markdown@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "mdast-util-to-markdown@npm:1.3.0"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    "@types/unist": ^2.0.0
+    longest-streak: ^3.0.0
+    mdast-util-to-string: ^3.0.0
+    micromark-util-decode-string: ^1.0.0
+    unist-util-visit: ^4.0.0
+    zwitch: ^2.0.0
+  checksum: 0ea4fc11b7a49b15d400d50044429c45222cb9bc583553288c7c54704d051f25049233817129ba56a6f581f1e20916e5c540870a80987318747a95b44a36ba3e
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^3.0.0, mdast-util-to-string@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mdast-util-to-string@npm:3.1.0"
+  checksum: f42ddd4e22f2215a75715b92ea6e3149c4ba356e7781d7b94fc86ded1c79cec3f986afeecef3a4a80068c9b224a6520099783a12146b957de24f020a3e47dd29
+  languageName: node
+  linkType: hard
+
 "mdn-data@npm:2.0.14":
   version: 2.0.14
   resolution: "mdn-data@npm:2.0.14"
@@ -14939,6 +15248,13 @@ __metadata:
   version: 2.0.4
   resolution: "mdn-data@npm:2.0.4"
   checksum: add3c95e6d03d301b8a8bcfee3de33f4d07e4c5eee5b79f18d6d737de717e22472deadf67c1a8563983c0b603e10d7df40aa8e5fddf18884dfe118ccec7ae329
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mdurl@npm:1.0.1"
+  checksum: 71731ecba943926bfbf9f9b51e28b5945f9411c4eda80894221b47cc105afa43ba2da820732b436f0798fd3edbbffcd1fc1415843c41a87fea08a41cc1e3d02b
   languageName: node
   linkType: hard
 
@@ -15029,6 +15345,337 @@ __metadata:
   version: 0.1.1
   resolution: "microevent.ts@npm:0.1.1"
   checksum: 7874fcdb3f0dfa4e996d3ea63b3b9882874ae7d22be28d51ae20da24c712e9e28e5011d988095c27dd2b32e37c0ad7425342a71b89adb8e808ec7194fadf4a7a
+  languageName: node
+  linkType: hard
+
+"micromark-core-commonmark@npm:^1.0.0, micromark-core-commonmark@npm:^1.0.1":
+  version: 1.0.6
+  resolution: "micromark-core-commonmark@npm:1.0.6"
+  dependencies:
+    decode-named-character-reference: ^1.0.0
+    micromark-factory-destination: ^1.0.0
+    micromark-factory-label: ^1.0.0
+    micromark-factory-space: ^1.0.0
+    micromark-factory-title: ^1.0.0
+    micromark-factory-whitespace: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-chunked: ^1.0.0
+    micromark-util-classify-character: ^1.0.0
+    micromark-util-html-tag-name: ^1.0.0
+    micromark-util-normalize-identifier: ^1.0.0
+    micromark-util-resolve-all: ^1.0.0
+    micromark-util-subtokenize: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.1
+    uvu: ^0.5.0
+  checksum: 4b483c46077f696ed310f6d709bb9547434c218ceb5c1220fde1707175f6f68b44da15ab8668f9c801e1a123210071e3af883a7d1215122c913fd626f122bfc2
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-autolink-literal@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "micromark-extension-gfm-autolink-literal@npm:1.0.3"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-sanitize-uri: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: bb181972ac346ca73ca1ab0b80b80c9d6509ed149799d2217d5442670f499c38a94edff73d32fa52b390d89640974cfbd7f29e4ad7d599581d5e1cabcae636a2
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-footnote@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "micromark-extension-gfm-footnote@npm:1.0.4"
+  dependencies:
+    micromark-core-commonmark: ^1.0.0
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-normalize-identifier: ^1.0.0
+    micromark-util-sanitize-uri: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: 8daa203f5cf753338d5ecdbaae6b3ab6319d34b6013b90ea6860bed299418cecf86e69e48dabe42562e334760c738c77c5acdb47e75ae26f5f01f02f3bf0952d
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-strikethrough@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "micromark-extension-gfm-strikethrough@npm:1.0.4"
+  dependencies:
+    micromark-util-chunked: ^1.0.0
+    micromark-util-classify-character: ^1.0.0
+    micromark-util-resolve-all: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: f43d316b85fe93df1711cdcdc99a5320b941239349234bd262fc708cb67ad47bdfb41d1a7ebe2a5829816b0e9d3107380a5c1e558cb536a75354cbe4857823ba
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-table@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "micromark-extension-gfm-table@npm:1.0.5"
+  dependencies:
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: f0aab3b4333cc24b1534b08dc4cce986dd606df8b7ed913e5a1de9fe2d3ae67b2435663c0bc271b528874af4928e580e1ad540ea9117d7f2d74edb28859c97ef
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-tagfilter@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "micromark-extension-gfm-tagfilter@npm:1.0.1"
+  dependencies:
+    micromark-util-types: ^1.0.0
+  checksum: 63e8d68f25871722900a67a8001d5da21f19ea707f3566fc7d0b2eb1f6d52476848bb6a41576cf22470565124af9497c5aae842355faa4c14ec19cb1847e71ec
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-task-list-item@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "micromark-extension-gfm-task-list-item@npm:1.0.3"
+  dependencies:
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: d320b0c5301f87e211c06a2330d1ee0fee6da14f0d6d44d5211055b465dadff34390cd6b258a5e0ca376fcda3364fef9a12fe6e26a0c858231fa3b98ddbf7785
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-extension-gfm@npm:2.0.1"
+  dependencies:
+    micromark-extension-gfm-autolink-literal: ^1.0.0
+    micromark-extension-gfm-footnote: ^1.0.0
+    micromark-extension-gfm-strikethrough: ^1.0.0
+    micromark-extension-gfm-table: ^1.0.0
+    micromark-extension-gfm-tagfilter: ^1.0.0
+    micromark-extension-gfm-task-list-item: ^1.0.0
+    micromark-util-combine-extensions: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: b181479c87be38d5ae8d28e6dc52fab73c894fd2706876746f27a91fb186644ce03532a9c35dca2186327a0e2285cd5242ad0361dc89adedd4a50376ffd94e22
+  languageName: node
+  linkType: hard
+
+"micromark-factory-destination@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-factory-destination@npm:1.0.0"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 8e733ae9c1c2342f14ff290bf09946e20f6f540117d80342377a765cac48df2ea5e748f33c8b07501ad7a43414b1a6597c8510ede2052b6bf1251fab89748e20
+  languageName: node
+  linkType: hard
+
+"micromark-factory-label@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "micromark-factory-label@npm:1.0.2"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: 957e9366bdc8dbc1437c0706ff96972fa985ab4b1274abcae12f6094f527cbf5c69e7f2304c23c7f4b96e311ff7911d226563b8b43dcfcd4091e8c985fb97ce6
+  languageName: node
+  linkType: hard
+
+"micromark-factory-space@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-factory-space@npm:1.0.0"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 70d3aafde4e68ef4e509a3b644e9a29e4aada00801279e346577b008cbca06d78051bcd62aa7ea7425856ed73f09abd2b36607803055f726f52607ee7cb706b0
+  languageName: node
+  linkType: hard
+
+"micromark-factory-title@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "micromark-factory-title@npm:1.0.2"
+  dependencies:
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: 9a9cf66babde0bad1e25d6c1087082bfde6dfc319a36cab67c89651cc1a53d0e21cdec83262b5a4c33bff49f0e3c8dc2a7bd464e991d40dbea166a8f9b37e5b2
+  languageName: node
+  linkType: hard
+
+"micromark-factory-whitespace@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-factory-whitespace@npm:1.0.0"
+  dependencies:
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 0888386e6ea2dd665a5182c570d9b3d0a172d3f11694ca5a2a84e552149c9f1429f5b975ec26e1f0fa4388c55a656c9f359ce5e0603aff6175ba3e255076f20b
+  languageName: node
+  linkType: hard
+
+"micromark-util-character@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "micromark-util-character@npm:1.1.0"
+  dependencies:
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 504a4e3321f69bddf3fec9f0c1058239fc23336bda5be31d532b150491eda47965a251b37f8a7a9db0c65933b3aaa49cf88044fb1028be3af7c5ee6212bf8d5f
+  languageName: node
+  linkType: hard
+
+"micromark-util-chunked@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-chunked@npm:1.0.0"
+  dependencies:
+    micromark-util-symbol: ^1.0.0
+  checksum: c1efd56e8c4217bcf1c6f1a9fb9912b4a2a5503b00d031da902be922fb3fee60409ac53f11739991291357b2784fb0647ddfc74c94753a068646c0cb0fd71421
+  languageName: node
+  linkType: hard
+
+"micromark-util-classify-character@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-classify-character@npm:1.0.0"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 180446e6a1dec653f625ded028f244784e1db8d10ad05c5d70f08af9de393b4a03dc6cf6fa5ed8ccc9c24bbece7837abf3bf66681c0b4adf159364b7d5236dfd
+  languageName: node
+  linkType: hard
+
+"micromark-util-combine-extensions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-combine-extensions@npm:1.0.0"
+  dependencies:
+    micromark-util-chunked: ^1.0.0
+    micromark-util-types: ^1.0.0
+  checksum: 5304a820ef75340e1be69d6ad167055b6ba9a3bafe8171e5945a935752f462415a9dd61eb3490220c055a8a11167209a45bfa73f278338b7d3d61fa1464d3f35
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-numeric-character-reference@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-decode-numeric-character-reference@npm:1.0.0"
+  dependencies:
+    micromark-util-symbol: ^1.0.0
+  checksum: f3ae2bb582a80f1e9d3face026f585c0c472335c064bd850bde152376f0394cb2831746749b6be6e0160f7d73626f67d10716026c04c87f402c0dd45a1a28633
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-string@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "micromark-util-decode-string@npm:1.0.2"
+  dependencies:
+    decode-named-character-reference: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-decode-numeric-character-reference: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+  checksum: 2dbb41c9691cc71505d39706405139fb7d6699429d577a524c7c248ac0cfd09d3dd212ad8e91c143a00b2896f26f81136edc67c5bda32d20446f0834d261b17a
+  languageName: node
+  linkType: hard
+
+"micromark-util-encode@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "micromark-util-encode@npm:1.0.1"
+  checksum: 9290583abfdc79ea3e7eb92c012c47a0e14327888f8aaa6f57ff79b3058d8e7743716b9d91abca3646f15ab3d78fdad9779fdb4ccf13349cd53309dfc845253a
+  languageName: node
+  linkType: hard
+
+"micromark-util-html-tag-name@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-html-tag-name@npm:1.0.0"
+  checksum: ed07ce9b9bb30cc4ea57f733089b3a253a6132c0608ccfc105eadb32f1f80bbd2347bf8a74f897fe039d7805a59f602fd4dd15f6adc7926d40b3646da2888d0f
+  languageName: node
+  linkType: hard
+
+"micromark-util-normalize-identifier@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-normalize-identifier@npm:1.0.0"
+  dependencies:
+    micromark-util-symbol: ^1.0.0
+  checksum: d7c09d5e8318fb72f194af72664bd84a48a2928e3550b2b21c8fbc0ec22524f2a72e0f6663d2b95dc189a6957d3d7759b60716e888909710767cd557be821f8b
+  languageName: node
+  linkType: hard
+
+"micromark-util-resolve-all@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-resolve-all@npm:1.0.0"
+  dependencies:
+    micromark-util-types: ^1.0.0
+  checksum: 409667f2bd126ef8acce009270d2aecaaa5584c5807672bc657b09e50aa91bd2e552cf41e5be1e6469244a83349cbb71daf6059b746b1c44e3f35446fef63e50
+  languageName: node
+  linkType: hard
+
+"micromark-util-sanitize-uri@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "micromark-util-sanitize-uri@npm:1.0.0"
+  dependencies:
+    micromark-util-character: ^1.0.0
+    micromark-util-encode: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+  checksum: 77448ec3a5d18f0ac975ea47591fbf0d5bd5568f9a0d033d9e318f90656031f037c5ff9137e93faf289480eaea70a5382e2571ebf9edcb1c1cd2a5187b6b3160
+  languageName: node
+  linkType: hard
+
+"micromark-util-subtokenize@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "micromark-util-subtokenize@npm:1.0.2"
+  dependencies:
+    micromark-util-chunked: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.0
+    uvu: ^0.5.0
+  checksum: c32ee58a7e1384ab1161a9ee02fbb04ad7b6e96d0b8c93dba9803c329a53d07f22ab394c7a96b2e30d6b8fbe3585b85817dba07277b1317111fc234e166bd2d1
+  languageName: node
+  linkType: hard
+
+"micromark-util-symbol@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "micromark-util-symbol@npm:1.0.1"
+  checksum: c6a3023b3a7432c15864b5e33a1bcb5042ac7aa097f2f452e587bef45433d42d39e0a5cce12fbea91e0671098ba0c3f62a2b30ce1cde66ecbb5e8336acf4391d
+  languageName: node
+  linkType: hard
+
+"micromark-util-types@npm:^1.0.0, micromark-util-types@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "micromark-util-types@npm:1.0.2"
+  checksum: 08dc901b7c06ee3dfeb54befca05cbdab9525c1cf1c1080967c3878c9e72cb9856c7e8ff6112816e18ead36ce6f99d55aaa91560768f2f6417b415dcba1244df
+  languageName: node
+  linkType: hard
+
+"micromark@npm:^3.0.0":
+  version: 3.0.10
+  resolution: "micromark@npm:3.0.10"
+  dependencies:
+    "@types/debug": ^4.0.0
+    debug: ^4.0.0
+    decode-named-character-reference: ^1.0.0
+    micromark-core-commonmark: ^1.0.1
+    micromark-factory-space: ^1.0.0
+    micromark-util-character: ^1.0.0
+    micromark-util-chunked: ^1.0.0
+    micromark-util-combine-extensions: ^1.0.0
+    micromark-util-decode-numeric-character-reference: ^1.0.0
+    micromark-util-encode: ^1.0.0
+    micromark-util-normalize-identifier: ^1.0.0
+    micromark-util-resolve-all: ^1.0.0
+    micromark-util-sanitize-uri: ^1.0.0
+    micromark-util-subtokenize: ^1.0.0
+    micromark-util-symbol: ^1.0.0
+    micromark-util-types: ^1.0.1
+    uvu: ^0.5.0
+  checksum: 04663fe0308cccfbf338111b41d3d82d6445d1d2b834c9fc1880e1ea3874c4a3b81adfafe62b0bc7708ba0a86889885ea31b4dbb39f1f72190c3aab46b743bb1
   languageName: node
   linkType: hard
 
@@ -15367,6 +16014,13 @@ __metadata:
     rimraf: ^2.5.4
     run-queue: ^1.0.3
   checksum: 4ea3296c150b09e798177847f673eb5783f8ca417ba806668d2c631739f653e1a735f19fb9b6e2f5e25ee2e4c0a6224732237a8e4f84c764e99d7462d258209e
+  languageName: node
+  linkType: hard
+
+"mri@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "mri@npm:1.2.0"
+  checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
   languageName: node
   linkType: hard
 
@@ -18320,7 +18974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.10, prop-types@npm:^15.5.6, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.6, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -18328,6 +18982,13 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
+"property-information@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "property-information@npm:6.1.1"
+  checksum: 654b1e5c3578e1d522bd22b7cf48881f5054789969ddbefea22e5359805fda5dbf0c5ef76bb26516da26fedac8752587ddc4c8f3b9e16bc0c6e7feb8b6086864
   languageName: node
   linkType: hard
 
@@ -18803,6 +19464,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^18.0.0":
+  version: 18.1.0
+  resolution: "react-is@npm:18.1.0"
+  checksum: d206a0fe6790851bff168727bfb896de02c5591695afb0c441163e8630136a3e13ee1a7ddd59fdccddcc93968b4721ae112c10f790b194b03b35a3dc13a355ef
+  languageName: node
+  linkType: hard
+
+"react-markdown@npm:8.0.3":
+  version: 8.0.3
+  resolution: "react-markdown@npm:8.0.3"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/prop-types": ^15.0.0
+    "@types/unist": ^2.0.0
+    comma-separated-tokens: ^2.0.0
+    hast-util-whitespace: ^2.0.0
+    prop-types: ^15.0.0
+    property-information: ^6.0.0
+    react-is: ^18.0.0
+    remark-parse: ^10.0.0
+    remark-rehype: ^10.0.0
+    space-separated-tokens: ^2.0.0
+    style-to-object: ^0.3.0
+    unified: ^10.0.0
+    unist-util-visit: ^4.0.0
+    vfile: ^5.0.0
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 66c0b45889d0262168547d9356145ced276993dac1d441c5c1cf2371fe71f347419696f9040c084c7d77c1caced21d358677c38f66edae736f942ac5964c032f
+  languageName: node
+  linkType: hard
+
 "react-query@npm:3.34.16":
   version: 3.34.16
   resolution: "react-query@npm:3.34.16"
@@ -19272,6 +19966,52 @@ __metadata:
   version: 0.2.7
   resolution: "relateurl@npm:0.2.7"
   checksum: 5891e792eae1dfc3da91c6fda76d6c3de0333a60aa5ad848982ebb6dccaa06e86385fb1235a1582c680a3d445d31be01c6bfc0804ebbcab5aaf53fa856fde6b6
+  languageName: node
+  linkType: hard
+
+"remark-breaks@npm:3.0.2":
+  version: 3.0.2
+  resolution: "remark-breaks@npm:3.0.2"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    unified: ^10.0.0
+    unist-util-visit: ^4.0.0
+  checksum: 5f46b18818f8a77e4fbc607c99736eedbe1f8cbad3d7390ce8359f08e3b749de8778ec8812287a41f51ffef2524b0be0dd623fcdbcda5de7f13f9902851f80b3
+  languageName: node
+  linkType: hard
+
+"remark-gfm@npm:3.0.1":
+  version: 3.0.1
+  resolution: "remark-gfm@npm:3.0.1"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-gfm: ^2.0.0
+    micromark-extension-gfm: ^2.0.0
+    unified: ^10.0.0
+  checksum: 02254f74d67b3419c2c9cf62d799ec35f6c6cd74db25c001361751991552a7ce86049a972107bff8122d85d15ae4a8d1a0618f3bc01a7df837af021ae9b2a04e
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "remark-parse@npm:10.0.1"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-from-markdown: ^1.0.0
+    unified: ^10.0.0
+  checksum: 505088e564ab53ff054433368adbb7b551f69240c7d9768975529837a86f1d0f085e72d6211929c5c42db315273df4afc94f3d3a8662ffdb69468534c6643d29
+  languageName: node
+  linkType: hard
+
+"remark-rehype@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "remark-rehype@npm:10.1.0"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/mdast": ^3.0.0
+    mdast-util-to-hast: ^12.1.0
+    unified: ^10.0.0
+  checksum: b9ac8acff3383b204dfdc2599d0bdf86e6ca7e837033209584af2e6aaa6a9013e519a379afa3201299798cab7298c8f4b388de118c312c67234c133318aec084
   languageName: node
   linkType: hard
 
@@ -19794,6 +20534,15 @@ __metadata:
   dependencies:
     tslib: ^2.1.0
   checksum: e034f60805210cce756dd2f49664a8108780b117cf5d0e2281506e9e6387f7b4f1532d974a8c8b09314fa7a16dd2f6cff3462072a5789672b5dcb45c4173f3c6
+  languageName: node
+  linkType: hard
+
+"sade@npm:^1.7.3":
+  version: 1.8.1
+  resolution: "sade@npm:1.8.1"
+  dependencies:
+    mri: ^1.1.0
+  checksum: 0756e5b04c51ccdc8221ebffd1548d0ce5a783a44a0fa9017a026659b97d632913e78f7dca59f2496aa996a0be0b0c322afd87ca72ccd909406f49dbffa0f45d
   languageName: node
   linkType: hard
 
@@ -20545,6 +21294,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"space-separated-tokens@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "space-separated-tokens@npm:2.0.1"
+  checksum: 66e30a6382d6e3ab0a6573d510235a198202071d4ebfef8c198f10433166f0cdced4dbf0946cad3c4b2ecc336896a11f98b2ec93047e140fe7aef6fd3a21365b
+  languageName: node
+  linkType: hard
+
 "spdx-correct@npm:^3.0.0":
   version: 3.1.1
   resolution: "spdx-correct@npm:3.1.1"
@@ -21056,6 +21812,15 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 470feef680f59e2fce4d6601b5c55b88c01ad8d1dd693c528ffd591ff5fd7c01a4eff3bdbe62f26f847d6bd2430c9ab594be23307cfe7a3446ab236683f0d066
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "style-to-object@npm:0.3.0"
+  dependencies:
+    inline-style-parser: 0.1.1
+  checksum: 4d7084015207f2a606dfc10c29cb5ba569f2fe8005551df7396110dd694d6ff650f2debafa95bd5d147dfb4ca50f57868e2a7f91bf5d11ef734fe7ccbd7abf59
   languageName: node
   linkType: hard
 
@@ -21623,6 +22388,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trough@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "trough@npm:2.1.0"
+  checksum: a577bb561c2b401cc0e1d9e188fcfcdf63b09b151ff56a668da12197fe97cac15e3d77d5b51f426ccfd94255744a9118e9e9935afe81a3644fa1be9783c82886
+  languageName: node
+  linkType: hard
+
 "tryer@npm:^1.0.1":
   version: 1.0.1
   resolution: "tryer@npm:1.0.1"
@@ -21993,6 +22765,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unified@npm:^10.0.0":
+  version: 10.1.2
+  resolution: "unified@npm:10.1.2"
+  dependencies:
+    "@types/unist": ^2.0.0
+    bail: ^2.0.0
+    extend: ^3.0.0
+    is-buffer: ^2.0.0
+    is-plain-obj: ^4.0.0
+    trough: ^2.0.0
+    vfile: ^5.0.0
+  checksum: 053e7c65ede644607f87bd625a299e4b709869d2f76ec8138569e6e886903b6988b21cd9699e471eda42bee189527be0a9dac05936f1d069a5e65d0125d5d756
+  languageName: node
+  linkType: hard
+
 "union-value@npm:^1.0.0":
   version: 1.0.1
   resolution: "union-value@npm:1.0.1"
@@ -22052,6 +22839,89 @@ __metadata:
   dependencies:
     crypto-random-string: ^2.0.0
   checksum: ef68f639136bcfe040cf7e3cd7a8dff076a665288122855148a6f7134092e6ed33bf83a7f3a9185e46c98dddc445a0da6ac25612afa1a7c38b8b654d6c02498e
+  languageName: node
+  linkType: hard
+
+"unist-builder@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unist-builder@npm:3.0.0"
+  dependencies:
+    "@types/unist": ^2.0.0
+  checksum: 80459ee3c2ece90bbc4f4b4faeed524d144c1a09ee07ff3e9004648d9b71a652e80a3b3ef60311a1e92f6ab915caf27c6f08062b5f8c84fa725bc0d7c5759e84
+  languageName: node
+  linkType: hard
+
+"unist-util-generated@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unist-util-generated@npm:2.0.0"
+  checksum: 3a806793fa24a75190c217740ce706340d6cb0d51eff677134253d628f8e4355ebd8a243fe8045c583463f6bebfd50f902d653161da87c1359fcd1a14b99c8e0
+  languageName: node
+  linkType: hard
+
+"unist-util-is@npm:^5.0.0":
+  version: 5.1.1
+  resolution: "unist-util-is@npm:5.1.1"
+  checksum: e8743a19a304d8a8f5684f3e5ddb5546f2655847b42123687277d76566a2aba89beb7b4a8a9e9ebc4d904cd1cecc285356d7923d973a43cfc19a1e10ff6bdee4
+  languageName: node
+  linkType: hard
+
+"unist-util-position@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "unist-util-position@npm:4.0.3"
+  dependencies:
+    "@types/unist": ^2.0.0
+  checksum: 0d89973628d40f19345cbcc50008f7f56d411afa54434bbe6c224b22d26aaf9d4500da2de363f1f01945acab1f1c31920c514253149eb546ff9b8bbc1ea94209
+  languageName: node
+  linkType: hard
+
+"unist-util-stringify-position@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "unist-util-stringify-position@npm:3.0.2"
+  dependencies:
+    "@types/unist": ^2.0.0
+  checksum: 2dfd7a0fb2a55e99cc319c3bf7f9f1f73ed652978fa70d19117faa7245d20f21738ec926ecc47f341705ca1bb157e87ced0b6bb5ecaa666bd2ae6b2510d6a671
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "unist-util-visit-parents@npm:4.1.1"
+  dependencies:
+    "@types/unist": ^2.0.0
+    unist-util-is: ^5.0.0
+  checksum: 49d78984a6dd858a989f849d2b4330c8a04d1ee99c0e9920a5e37668cf847dab95db77a3bf0c8aaeb3e66abeae12e2d454949ec401614efef377d8f82d215662
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "unist-util-visit-parents@npm:5.1.0"
+  dependencies:
+    "@types/unist": ^2.0.0
+    unist-util-is: ^5.0.0
+  checksum: 7c413dbb3dfcb679109fa8f0965d9abf117c3c53fa7b8823f68cac0ea53adbe98c1ce954d36c034e086c966b48b1d44d42c85f7bf6b42a032f728ac338929513
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "unist-util-visit@npm:3.1.0"
+  dependencies:
+    "@types/unist": ^2.0.0
+    unist-util-is: ^5.0.0
+    unist-util-visit-parents: ^4.0.0
+  checksum: c37dbc0c5509f85f3abdf46d927b3dd11e6c419159771b1f1a5ce446d36ac993d04b087e28bc6173a172e0fbe9d77e997f120029b2b449766ebe55b6f6e0cc2c
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "unist-util-visit@npm:4.1.0"
+  dependencies:
+    "@types/unist": ^2.0.0
+    unist-util-is: ^5.0.0
+    unist-util-visit-parents: ^5.0.0
+  checksum: 3521abee2ed4535092aac073d05f46255475c89781b8e9d8c951a473d91b5d6e4d5912ae4a68a4c1cf17a42ed0108cb93103c7f5c736977529969997451363fb
   languageName: node
   linkType: hard
 
@@ -22256,6 +23126,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uvu@npm:^0.5.0":
+  version: 0.5.3
+  resolution: "uvu@npm:0.5.3"
+  dependencies:
+    dequal: ^2.0.0
+    diff: ^5.0.0
+    kleur: ^4.0.3
+    sade: ^1.7.3
+  bin:
+    uvu: bin.js
+  checksum: 0cf8e9e6ec79199dacc64fe0e9f82b5bf1d2308f3c54ec1aba5d1ca0a4beff4f173cae0f87bc52d35121565fd232b969fbf52cca3707e20517e62645e19b898e
+  languageName: node
+  linkType: hard
+
 "v8-compile-cache-lib@npm:^3.0.0":
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
@@ -22324,6 +23208,28 @@ __metadata:
     core-util-is: 1.0.2
     extsprintf: ^1.2.0
   checksum: c431df0bedf2088b227a4e051e0ff4ca54df2c114096b0c01e1cbaadb021c30a04d7dd5b41ab277bcd51246ca135bf931d4c4c796ecae7a4fef6d744ecef36ea
+  languageName: node
+  linkType: hard
+
+"vfile-message@npm:^3.0.0":
+  version: 3.1.2
+  resolution: "vfile-message@npm:3.1.2"
+  dependencies:
+    "@types/unist": ^2.0.0
+    unist-util-stringify-position: ^3.0.0
+  checksum: 96fbd9e9b5e0babb5ee61e3a716dc7a6a8c28f2c8c711837d95c88b782161b31549ad16059a78990d7b836d0f4d3b4d8c9ffde44370d48d9cac991fc1e3e17c5
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "vfile@npm:5.3.2"
+  dependencies:
+    "@types/unist": ^2.0.0
+    is-buffer: ^2.0.0
+    unist-util-stringify-position: ^3.0.0
+    vfile-message: ^3.0.0
+  checksum: c352a76974c4ce0a0177e157335c95a647dae9e510ed4fad9b328479eb46230dc9ade8793d4c8b7f78263314797fc5026ff14da086e3805d530645e7d8057dcb
   languageName: node
   linkType: hard
 
@@ -23518,5 +24424,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "zwitch@npm:2.0.2"
+  checksum: 8edd7af8375f12f64d8dbef815af32cd77bd9237d0b013210ba4e3aef25fdc460fe264cd0a19deabe9f86ef0c607240ebac1a336bf4a70bf06ef53e0652de116
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR fixes the overflow bug on the messages and adds markdown support to
messages.

Preview of link not overflowing:
<img width="289" alt="Screenshot 2022-05-18 at 18 33 45" src="https://user-images.githubusercontent.com/39373170/169095572-ad3f2762-e45b-483e-a9e4-e2a2c2fffaa3.png">

And Preview of markdown comment:
<img width="294" alt="Screenshot 2022-05-18 at 18 34 03" src="https://user-images.githubusercontent.com/39373170/169095627-8b531e74-a32a-4ffb-a499-c4616191338c.png">

Styles are crafted manually, so some tweaking may be required, feedback is appreciated 😊

closes #40
